### PR TITLE
Change Validation type to Filled

### DIFF
--- a/blormlib/src/main/java/br/com/bloder/blormlib/validation/Validations.java
+++ b/blormlib/src/main/java/br/com/bloder/blormlib/validation/Validations.java
@@ -11,7 +11,7 @@ import br.com.bloder.blormlib.validation.validations.Number;
  */
 public class Validations {
 
-  public static Validation filled = new Filled();
+  public static Filled filled = new Filled();
   public static Validation checked = new Checked();
   public static Validation email = new Email();
   public static Number number = new Number();


### PR DESCRIPTION
[Filled is not a filled instanstance but should be](https://github.com/daniel-martins-IR/Blorm/blob/master/blormlib/src/main/java/br/com/bloder/blormlib/validation/Validations.java#L14), it currently is a validation, the type should be switched to allow filled extended methods to work.
